### PR TITLE
Fix for icons appearing off-centre in Webkit

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -306,7 +306,7 @@ h1, h2 {
     border: none;
     background-color: transparent;
     transition: background 0.3s ease;
-    padding: 8px;
+    padding: 1px;
     color: inherit;
     font:inherit;
     font-size: 24px;


### PR DESCRIPTION
Tested in Google Chrome 37 and Firefox 31 for Ubuntu
