### PR TITLE
Use // rather than http:// to fix mixed http+https content issue

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -2,7 +2,7 @@
 /******** by Tim Nguyen *************/
 /** http://twitter.com/therealntim **/
 
-@import url(http://fonts.googleapis.com/css?family=Roboto:500,400,300,300italic,400italic,500italic);
+@import url(//fonts.googleapis.com/css?family=Roboto:500,400,300,300italic,400italic,500italic);
 body {
     font-family: Roboto, Arial, sans-serif;
     color: rgba(0,0,0,0.87);


### PR DESCRIPTION
Fixed an issue causing the Roboto font not to load caused by mixed HTTP and HTTPS content, unless you override in the browser
(it's me, I changed my nick from "devilishdb" to "robocoder-db")