### PR TITLE
fix #67

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -646,7 +646,6 @@ p {
 	display: inline-block;
 	text-decoration: inherit;
 	width: 1em;
-	margin-right: .2em;
 	text-align: center;
 	/* opacity: .8; */
  
@@ -656,10 +655,6 @@ p {
 	 
 	/* fix buttons height, for twitter bootstrap */
 	line-height: 1em;
- 
-	/* Animation center compensation - margins should be symmetric */
-	/* remove if not needed */
-	margin-left: .2em;
  
 	/* you can be more comfortable with increased icons size */
 	/* font-size: 120%; */

--- a/css/material.css
+++ b/css/material.css
@@ -70,7 +70,7 @@ h1, .heading {
 h2, .subheading {
 	padding: 0;
 	margin: 0;
-	padding-left: 16px;
+	padding-left: 1em;
 	font-size: 1em;
 	line-height: 3em;
 	position: -webkit-sticky;


### PR DESCRIPTION
Fix #67 by removing margins around icons. Gecko and others take the text-align:center of the button and the equal margins and centers the icon, while webkit applies the margins and lets the element overflow. (this also happens in the large fab buttons, it's just less obvious). Not sure if this is a good solution to this or not - does having no margin around icons cause other layout issues?

The other option would be only removing the margin for icons inside a fab button.