### PR TITLE
fix dialog closing animation

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -883,7 +883,6 @@ code {
 	opacity: 0;
 	pointer-events: none;
 	z-index: -1;
-	max-height: 0;
 	-webkit-transform: translate(-50%, -100%);
 	transform: translate(-50%, -100%);
 }


### PR DESCRIPTION
prevent the dialog from briefly showing scrollbars as it fades out. Also improves performance because the height is not being recalculated.