### PR TITLE
add padding to the top and bottom of menus

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -933,6 +933,7 @@ code {
 /* Menu */
 .menu {
 	display: inline-block;
+	padding: 0.5em 0;
 	list-style: none;
 	background-color: #fff;
 	color: rgba(0, 0, 0, 0.87);


### PR DESCRIPTION
According to the <a href="http://www.google.com/design/spec/components/menus.html#menus-specs">spec</a>, menus should have 0.5em of padding at the top and bottom. This makes the last item look weird when it is after a divider, but the spec doesn't really say anything about this.
