### PR TITLE
vertically center `.item-icon` in `.list`

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -918,6 +918,7 @@ code {
 	vertical-align: top;
 	margin-right: 1em;
 	position: relative;
+    	align-self: center;	
 }
 .list > li .item-icon > i {
 	position: absolute;

--- a/css/material.css
+++ b/css/material.css
@@ -918,7 +918,9 @@ code {
 	vertical-align: top;
 	margin-right: 1em;
 	position: relative;
-    	align-self: center;	
+	-webkit-align-self: center;
+	-ms-flex-item-align: center;
+	align-self: center;
 }
 .list > li .item-icon > i {
 	position: absolute;


### PR DESCRIPTION
A quick throw-in fix for `.item-icon` vertical alignment, noticed while checking out the docs. cool project!