### PR TITLE
Fix for switch using default cursor

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -478,6 +478,9 @@ code {
 	-webkit-filter: brightness(110%);
 	filter: brightness(110%);
 }
+.switch label:not(.form-control-label) {
+	cursor: pointer;
+}
 
 /* Text inputs */
 .text-input,


### PR DESCRIPTION
While browsing through the documentation, I noticed the switches using the default browser cursor and not the "pointer" cursor. Here is a quick fix.